### PR TITLE
Fix auto-updater bricking the app on a truncated/partial patch (#48)

### DIFF
--- a/backend/tests/test_make_patch.py
+++ b/backend/tests/test_make_patch.py
@@ -1,0 +1,46 @@
+"""
+Tests for scripts/make_patch.py — the producer side of the update system.
+
+The updater rejects a downloaded patch whose sha256 doesn't match the manifest,
+so make_patch must record the *actual* checksum of the tarball it just wrote.
+This runs the real script against a minimal fake .app bundle via subprocess.
+"""
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def test_make_patch_records_matching_sha256(tmp_path):
+    # Minimal fake .app carrying the core patch files make_patch looks for
+    app = tmp_path / "Oligolia.app"
+    (app / "Contents" / "MacOS").mkdir(parents=True)
+    (app / "Contents" / "Resources").mkdir(parents=True)
+    (app / "Contents" / "MacOS" / "Oligolia").write_bytes(b"fake binary payload")
+    (app / "Contents" / "Resources" / "version.py").write_text("VERSION = '0.0.0'\n")
+    (app / "Contents" / "Info.plist").write_text("<plist></plist>")
+
+    out = tmp_path / "dist"
+    script = REPO_ROOT / "scripts" / "make_patch.py"
+    result = subprocess.run(
+        [sys.executable, str(script), str(app), str(out)],
+        cwd=str(REPO_ROOT), capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    manifests = list(out.glob("*-manifest.json"))
+    patches = list(out.glob("*-mac-patch.tar.gz"))
+    assert len(manifests) == 1, "expected exactly one manifest"
+    assert len(patches) == 1, "expected exactly one patch tarball"
+
+    manifest = json.loads(manifests[0].read_text())
+    assert "patch_sha256" in manifest, "manifest must carry a patch checksum"
+
+    expected = hashlib.sha256(patches[0].read_bytes()).hexdigest()
+    assert manifest["patch_sha256"] == expected, \
+        "manifest sha256 must match the bytes of the patch it describes"
+    assert len(manifest["patch_sha256"]) == 64

--- a/backend/tests/test_updater.py
+++ b/backend/tests/test_updater.py
@@ -410,6 +410,203 @@ def test_apply_code_patch_path_traversal_blocked():
             evil.unlink()
 
 
+# ── DownloadWorker integrity (partial-patch bug) ─────────────────────────────
+
+def _make_stream_resp(content_length, chunks):
+    """Build a mock httpx streaming response usable as a context manager."""
+    mock_resp = MagicMock()
+    mock_resp.headers = ({"content-length": str(content_length)}
+                         if content_length is not None else {})
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.iter_bytes.return_value = list(chunks)
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _run_worker(url, filename, resp, tmp_path, expected_sha256=""):
+    """Run a DownloadWorker against a mocked stream, writing into tmp_path.
+
+    Returns (finished_paths, errors).
+    """
+    from gui.updater import DownloadWorker
+
+    worker = DownloadWorker(url, filename, expected_sha256)
+    finished, errors = [], []
+    worker.progress = MagicMock()
+    worker.progress.emit = lambda v: None
+    worker.finished = MagicMock()
+    worker.finished.emit = lambda p: finished.append(p)
+    worker.error = MagicMock()
+    worker.error.emit = lambda e: errors.append(e)
+
+    with patch("tempfile.gettempdir", return_value=str(tmp_path)), \
+         patch("httpx.Client") as mock_client_cls:
+        client_instance = MagicMock()
+        mock_client_cls.return_value.__enter__.return_value = client_instance
+        client_instance.stream.return_value = resp
+        worker.run()
+    return finished, errors
+
+
+def test_download_worker_truncated_download_is_rejected(tmp_path):
+    """A stream that ends short of Content-Length must NOT be reported as finished.
+
+    Reproduces the 'partial patch' bug: the server promised 1000 bytes but the
+    connection dropped after 400. The old code emitted finished() with the
+    truncated file, which apply_code_patch then wrote over the live binary.
+    """
+    resp = _make_stream_resp(content_length=1000, chunks=[b"A" * 400])
+    finished, errors = _run_worker("http://x/patch.tar.gz", "patch.tar.gz", resp, tmp_path)
+
+    assert finished == [], "truncated download must not be reported as a completed file"
+    assert len(errors) == 1
+    # And the partial file must not be left lying around for a later apply
+    assert not (tmp_path / "patch.tar.gz").exists(), "partial file should be cleaned up"
+
+
+def test_download_worker_complete_download_succeeds(tmp_path):
+    """A stream matching Content-Length is accepted and written intact."""
+    resp = _make_stream_resp(content_length=1000, chunks=[b"A" * 500, b"A" * 500])
+    finished, errors = _run_worker("http://x/patch.tar.gz", "patch.tar.gz", resp, tmp_path)
+
+    assert errors == []
+    assert finished == [str(tmp_path / "patch.tar.gz")]
+    assert (tmp_path / "patch.tar.gz").read_bytes() == b"A" * 1000
+
+
+def test_download_worker_checksum_mismatch_is_rejected(tmp_path):
+    """A fully-downloaded but corrupt file (bad checksum) must be rejected.
+
+    Content-Length can be satisfied by a complete-but-corrupted body, or absent
+    entirely; the manifest sha256 is the backstop that still catches it.
+    """
+    payload = b"corrupted patch bytes"
+    resp = _make_stream_resp(content_length=len(payload), chunks=[payload])
+    finished, errors = _run_worker(
+        "http://x/patch.tar.gz", "patch.tar.gz", resp, tmp_path,
+        expected_sha256="00" * 32,  # deliberately wrong
+    )
+
+    assert finished == []
+    assert len(errors) == 1 and "Checksum mismatch" in errors[0]
+    assert not (tmp_path / "patch.tar.gz").exists()
+
+
+def test_download_worker_checksum_match_succeeds(tmp_path):
+    """A download whose sha256 matches the manifest is accepted."""
+    import hashlib
+    payload = b"the genuine patch bytes"
+    digest = hashlib.sha256(payload).hexdigest()
+    resp = _make_stream_resp(content_length=len(payload), chunks=[payload])
+    finished, errors = _run_worker(
+        "http://x/patch.tar.gz", "patch.tar.gz", resp, tmp_path,
+        expected_sha256=digest,
+    )
+
+    assert errors == []
+    assert finished == [str(tmp_path / "patch.tar.gz")]
+
+
+# ── UpdateInfo.expected_sha256 ───────────────────────────────────────────────
+
+def test_expected_sha256_returned_for_patch():
+    info = make_info("0.4.0", patch_url="http://x/patch.tar.gz", min_compat="0.0.0")
+    info.patch_sha256 = "abc123"
+    assert info.can_patch is True
+    assert info.expected_sha256 == "abc123"
+
+
+def test_expected_sha256_empty_for_full_install():
+    # Not patch-eligible → no checksum is applied to the full installer download
+    info = make_info("0.4.0", patch_url="", full_url="http://x/full.dmg")
+    info.patch_sha256 = "abc123"
+    assert info.can_patch is False
+    assert info.expected_sha256 == ""
+
+
+# ── apply_code_patch atomicity (breaks-the-app bug) ──────────────────────────
+
+def test_apply_code_patch_rolls_back_live_files_on_failure(tmp_path):
+    """A failure partway through applying a patch must not leave the installed
+    binary modified — otherwise a bad patch bricks the app.
+
+    We feed an archive whose first member is a valid replacement for the main
+    executable and whose second member is a path-traversal attack that aborts
+    the apply. The live executable must be unchanged afterwards.
+    """
+    fake_app = tmp_path / "Oligolia.app"
+    exe = fake_app / "Contents" / "MacOS" / "Oligolia"
+    exe.parent.mkdir(parents=True)
+    exe.write_bytes(b"OLD-WORKING-BINARY")
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        good = tarfile.TarInfo(name="Contents/MacOS/Oligolia")
+        good_data = b"NEW-BINARY"
+        good.size = len(good_data)
+        tar.addfile(good, io.BytesIO(good_data))
+        evil = tarfile.TarInfo(name="../../evil.txt")
+        evil_data = b"pwned"
+        evil.size = len(evil_data)
+        tar.addfile(evil, io.BytesIO(evil_data))
+    buf.seek(0)
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+        f.write(buf.read())
+        patch_path = f.name
+
+    try:
+        with patch("gui.updater._app_bundle_path", return_value=fake_app), \
+             patch("subprocess.run"):
+            with pytest.raises(RuntimeError, match="unsafe path"):
+                apply_code_patch(patch_path)
+
+        assert exe.read_bytes() == b"OLD-WORKING-BINARY", \
+            "live executable was clobbered before the patch was validated"
+    finally:
+        os.unlink(patch_path)
+
+
+def test_apply_code_patch_success_swaps_files_and_cleans_up(tmp_path):
+    """A valid patch replaces the targeted files, preserves the exec bit on the
+    main binary, and leaves no .oligolia-bak backups behind."""
+    fake_app = tmp_path / "Oligolia.app"
+    exe = fake_app / "Contents" / "MacOS" / "Oligolia"
+    ver = fake_app / "Contents" / "Resources" / "version.py"
+    exe.parent.mkdir(parents=True)
+    ver.parent.mkdir(parents=True)
+    exe.write_bytes(b"OLD-BINARY")
+    ver.write_text("VERSION = '1.0.0'\n")
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, data in [
+            ("Contents/MacOS/Oligolia", b"NEW-BINARY-CONTENT"),
+            ("Contents/Resources/version.py", b"VERSION = '2.0.0'\n"),
+        ]:
+            ti = tarfile.TarInfo(name=name)
+            ti.size = len(data)
+            tar.addfile(ti, io.BytesIO(data))
+    buf.seek(0)
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False) as f:
+        f.write(buf.read())
+        patch_path = f.name
+
+    try:
+        with patch("gui.updater._app_bundle_path", return_value=fake_app), \
+             patch("subprocess.run") as mock_run:
+            apply_code_patch(patch_path)
+
+        assert exe.read_bytes() == b"NEW-BINARY-CONTENT"
+        assert ver.read_text() == "VERSION = '2.0.0'\n"
+        assert os.access(exe, os.X_OK), "main binary should keep its executable bit"
+        assert not (exe.parent / "Oligolia.oligolia-bak").exists(), "backup not cleaned up"
+        # codesign should run once the swap is clean (remove-signature + re-sign)
+        assert mock_run.call_count == 2
+    finally:
+        os.unlink(patch_path)
+
+
 # ── restart_app ───────────────────────────────────────────────────────────────
 
 def test_restart_app_calls_execv():

--- a/gui/update_dialog.py
+++ b/gui/update_dialog.py
@@ -121,7 +121,7 @@ class UpdateDialog(QDialog):
         self._status.show()
         self._status.setText(f"Downloading {filename} ({self._info.download_size_hint})…")
 
-        self._worker = DownloadWorker(url, filename)
+        self._worker = DownloadWorker(url, filename, self._info.expected_sha256)
         self._worker.progress.connect(self._on_progress)
         self._worker.finished.connect(self._on_downloaded)
         self._worker.error.connect(self._on_error)

--- a/gui/updater.py
+++ b/gui/updater.py
@@ -28,6 +28,7 @@ import tempfile
 import subprocess
 import tarfile
 import shutil
+import hashlib
 import logging
 from pathlib import Path
 from packaging.version import Version
@@ -89,7 +90,7 @@ def _platform_full_asset(version: str) -> str:
 class UpdateInfo:
     def __init__(self, version: str, body: str, html_url: str,
                  patch_url: str, full_url: str, requires_full: bool,
-                 min_compatible_base: str) -> None:
+                 min_compatible_base: str, patch_sha256: str = "") -> None:
         self.version = version
         self.body = body
         self.html_url = html_url
@@ -97,6 +98,7 @@ class UpdateInfo:
         self.full_url = full_url
         self.requires_full = requires_full
         self.min_compatible_base = min_compatible_base
+        self.patch_sha256 = patch_sha256    # empty string = no integrity check
 
     @property
     def is_newer(self) -> bool:
@@ -122,6 +124,16 @@ class UpdateInfo:
     @property
     def download_size_hint(self) -> str:
         return "~11 MB (code patch)" if self.can_patch else "~260 MB (full installer)"
+
+    @property
+    def expected_sha256(self) -> str:
+        """Checksum to verify the chosen download against, if the manifest gave one.
+
+        Only the patch is checksummed here — the manifest is produced alongside
+        the patch (scripts/make_patch.py), whereas the full installer is built
+        separately by CI and carries its own OS-level integrity.
+        """
+        return self.patch_sha256 if self.can_patch else ""
 
 
 class UpdateChecker(QThread):
@@ -159,6 +171,7 @@ class UpdateChecker(QThread):
             manifest_url = assets.get(manifest_name, "")
             requires_full = False
             min_compat = "0.0.0"
+            patch_sha256 = ""
             patch_name = _platform_patch_asset(tag)
             full_name = _platform_full_asset(tag)
             _log.info("Looking for manifest: %s  found=%s", manifest_name, bool(manifest_url))
@@ -170,13 +183,14 @@ class UpdateChecker(QThread):
                     manifest = mresp.json()
                     requires_full = manifest.get("requires_full", False)
                     min_compat = manifest.get("min_compatible_base", "0.0.0")
+                    patch_sha256 = manifest.get("patch_sha256", "")
                     m_assets = manifest.get("assets", {})
                     if "darwin_patch" in m_assets and platform.system() == "Darwin":
                         patch_name = m_assets["darwin_patch"]
                     if "darwin_full" in m_assets and platform.system() == "Darwin":
                         full_name = m_assets["darwin_full"]
-                    _log.info("Manifest: requires_full=%s min_compat=%s patch_name=%s",
-                              requires_full, min_compat, patch_name)
+                    _log.info("Manifest: requires_full=%s min_compat=%s patch_name=%s sha256=%s",
+                              requires_full, min_compat, patch_name, patch_sha256[:12] or "(none)")
                 except Exception as e:
                     _log.warning("Manifest fetch failed: %s", e)
 
@@ -189,6 +203,7 @@ class UpdateChecker(QThread):
                 version=tag, body=body, html_url=html_url,
                 patch_url=patch_url, full_url=full_url,
                 requires_full=requires_full, min_compatible_base=min_compat,
+                patch_sha256=patch_sha256,
             )
             _log.info("is_newer=%s can_patch=%s download_url=%s",
                       info.is_newer, info.can_patch, info.download_url)
@@ -206,30 +221,55 @@ class DownloadWorker(QThread):
     finished = pyqtSignal(str)   # local file path
     error = pyqtSignal(str)
 
-    def __init__(self, url: str, filename: str) -> None:
+    def __init__(self, url: str, filename: str, expected_sha256: str = "") -> None:
         super().__init__()
         self._url = url
         self._filename = filename
+        self._expected_sha256 = (expected_sha256 or "").lower()
 
     def run(self) -> None:
+        dest = os.path.join(tempfile.gettempdir(), self._filename)
         try:
-            dest = os.path.join(tempfile.gettempdir(), self._filename)
             with httpx.Client(timeout=300, follow_redirects=True) as client:
                 with client.stream("GET", self._url) as r:
                     r.raise_for_status()
                     total = int(r.headers.get("content-length", 0))
                     downloaded = 0
+                    hasher = hashlib.sha256()
                     if not total:
                         # Signal indeterminate mode — dialog will pulse the bar
                         self.progress.emit(-1)
                     with open(dest, "wb") as f:
                         for chunk in r.iter_bytes(chunk_size=65536):
                             f.write(chunk)
+                            hasher.update(chunk)
                             downloaded += len(chunk)
                             if total:
                                 self.progress.emit(int(downloaded / total * 100))
+
+            # A dropped connection can end iter_bytes() without raising, leaving a
+            # truncated file. Refuse to hand a partial download to the patcher —
+            # otherwise it would overwrite the live app with an incomplete binary.
+            if total and downloaded != total:
+                raise RuntimeError(
+                    f"Incomplete download: received {downloaded} of {total} bytes"
+                )
+            if self._expected_sha256:
+                actual = hasher.hexdigest()
+                if actual != self._expected_sha256:
+                    raise RuntimeError(
+                        "Checksum mismatch — download is corrupt "
+                        f"(expected {self._expected_sha256[:12]}…, got {actual[:12]}…)"
+                    )
+
             self.finished.emit(dest)
         except Exception as e:
+            # Never leave a partial/corrupt file behind for the patcher to find
+            try:
+                if os.path.exists(dest):
+                    os.remove(dest)
+            except OSError:
+                pass
             self.error.emit(str(e))
 
 
@@ -241,26 +281,85 @@ def apply_code_patch(patch_path: str) -> None:
       Contents/MacOS/Oligolia        ← replace the main executable
       Contents/Resources/version.py  ← update version number
       Contents/Info.plist            ← update plist version strings
+
+    Two-phase, all-or-nothing apply so a bad patch can never brick the install:
+      1. Extract the ENTIRE archive to a staging dir. A truncated/corrupt tar.gz
+         raises here (bad gzip CRC / unexpected EOF) before the live bundle is
+         touched at all.
+      2. Back up each target, copy the staged files in, and roll every change
+         back on any failure — the running app is never left half-patched.
     """
     app = _app_bundle_path()
     if not app:
         raise RuntimeError("Cannot locate .app bundle — are you running from the installed app?")
+    app_root = str(app.resolve())
 
-    with tarfile.open(patch_path, "r:gz") as tar:
-        for member in tar.getmembers():
-            # Resolve destination and reject any path that escapes the .app bundle
-            dest = (app / member.name).resolve()
-            if not str(dest).startswith(str(app.resolve())):
-                raise RuntimeError(
-                    f"Patch contains unsafe path '{member.name}' — aborting"
-                )
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            if member.isfile():
-                with tar.extractfile(member) as src, open(dest, "wb") as dst:
+    staging = Path(tempfile.mkdtemp(prefix="oligolia_patch_"))
+    staging_root = str(staging.resolve())
+    try:
+        # ── Phase 1: extract + validate the whole archive into staging ──────────
+        members: list[str] = []
+        with tarfile.open(patch_path, "r:gz") as tar:
+            for member in tar.getmembers():
+                if not (member.isfile() or member.isdir()):
+                    continue  # skip symlinks/devices — patches only carry files
+                # Reject any path that escapes the .app bundle (or the staging dir)
+                if not str((app / member.name).resolve()).startswith(app_root):
+                    raise RuntimeError(
+                        f"Patch contains unsafe path '{member.name}' — aborting"
+                    )
+                staged = (staging / member.name).resolve()
+                if not str(staged).startswith(staging_root):
+                    raise RuntimeError(
+                        f"Patch contains unsafe path '{member.name}' — aborting"
+                    )
+                if member.isdir():
+                    staged.mkdir(parents=True, exist_ok=True)
+                    continue
+                staged.parent.mkdir(parents=True, exist_ok=True)
+                with tar.extractfile(member) as src, open(staged, "wb") as dst:
                     shutil.copyfileobj(src, dst)
+                members.append(member.name)
+
+        if not members:
+            raise RuntimeError("Patch contains no files — refusing to apply")
+
+        # ── Phase 2: swap staged files in, with backup + rollback ───────────────
+        backups: list[tuple[Path, Path | None]] = []  # (target, backup | None if new)
+        try:
+            for name in members:
+                target = (app / name).resolve()
+                target.parent.mkdir(parents=True, exist_ok=True)
+                if target.exists():
+                    bak = target.with_name(target.name + ".oligolia-bak")
+                    shutil.copy2(target, bak)
+                    backups.append((target, bak))
+                else:
+                    backups.append((target, None))
+                shutil.copyfile(staging / name, target)
                 # Preserve executable bit for the main binary
-                if "MacOS/" in member.name:
-                    os.chmod(dest, 0o755)
+                if "MacOS/" in name:
+                    os.chmod(target, 0o755)
+        except Exception:
+            # Restore every file we changed, newest change first
+            for target, bak in reversed(backups):
+                try:
+                    if bak is not None:
+                        shutil.copyfile(bak, target)
+                    elif target.exists():
+                        target.unlink()
+                except OSError:
+                    pass
+            raise
+        finally:
+            for _, bak in backups:
+                if bak is not None:
+                    try:
+                        bak.unlink()
+                    except OSError:
+                        pass
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
     # Clear code signature — patched binary won't match original sig
     subprocess.run(["codesign", "--remove-signature", str(app)],

--- a/scripts/make_patch.py
+++ b/scripts/make_patch.py
@@ -22,6 +22,7 @@ Defaults:
 import sys
 import tarfile
 import json
+import hashlib
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -83,11 +84,21 @@ def make_patch() -> None:
     patch_size = patch_path.stat().st_size
     print(f"\nPatch size:  {patch_size / 1024 / 1024:.1f} MB")
 
+    # Checksum the finished patch so the updater can reject a corrupt/truncated
+    # download before applying it.
+    hasher = hashlib.sha256()
+    with open(patch_path, "rb") as f:
+        for block in iter(lambda: f.read(1024 * 1024), b""):
+            hasher.update(block)
+    patch_sha256 = hasher.hexdigest()
+    print(f"SHA-256:     {patch_sha256}")
+
     # Generate manifest
     manifest = {
         "version": VERSION,
         "requires_full": False,
         "min_compatible_base": "0.3.0",  # oldest version this patch applies to
+        "patch_sha256": patch_sha256,
         "changelog": f"Oligolia {VERSION}",
         "assets": {
             "darwin_patch": patch_name,


### PR DESCRIPTION
Fixes #48.

## Problem
A dropped connection could end the download stream **without raising**, so `DownloadWorker` emitted `finished()` with a truncated file. `apply_code_patch` then wrote that partial archive over the live `.app` binary **in place, first member first, with no validation or rollback** — so a half-downloaded patch bricked the install, and the dialog's "falling back to full installer" message fired *after* the executable was already clobbered.

## Fix
- **`DownloadWorker`** now verifies the download actually completed — `content-length` match, plus a `sha256` checksum when the manifest provides one — before emitting `finished`. A partial/corrupt file is deleted rather than handed to the patcher.
- **`apply_code_patch`** is now two-phase and all-or-nothing:
  1. Extract + validate the **entire** archive into a staging dir. A truncated/corrupt `tar.gz` raises here, *before* the live bundle is touched.
  2. Swap staged files in with per-file backup + rollback on any failure. `codesign` runs only after a clean swap.
- **`make_patch.py`** records the patch tarball's `sha256` in the manifest so the updater can reject a corrupt download. (Backward compatible — absent checksum simply skips that check.)

## Tests
- Truncated download is rejected and the partial file cleaned up; complete download accepted.
- Checksum mismatch rejected; matching checksum accepted.
- `apply_code_patch` leaves the live binary byte-for-byte unchanged when a patch aborts mid-apply; success path swaps files, preserves the exec bit, and cleans up backups.
- New `test_make_patch.py` confirms the manifest `sha256` matches the emitted tarball.
- Full backend suite: **207 passed**. Lint clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)